### PR TITLE
Update Main With Develop To Finalize The Base Branch On August 30, 2025

### DIFF
--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "src/server.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "src/server.ts"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "truncate-html": "^1.2.2"
   },
   "engines": {
-    "node": "^20.0.0"
+    "node": "^22.0.0"
   },
   "packageManager": "yarn@1.22.22",
   "workspaces": [


### PR DESCRIPTION
1. Update Node Engine Version From ^20.0.0 to ^22.0.0 To Fix Vercel Deployment Issue
2. Resolved the Vercel deployment issue for the apps/backend service. By adding a vercel.json configuration file, I've instructed Vercel to handle your service as a Node.js serverless function, which is the correct approach for a backend application. You can now redeploy your service successfully.